### PR TITLE
I've updated `truffle-config.js` to use private keys.

### DIFF
--- a/components/providers/web3/index.js
+++ b/components/providers/web3/index.js
@@ -11,13 +11,14 @@ const setListeners = (provider) => {
 };
 
 export default function Web3Provider({ children }) {
-  const createWeb3State = ({ web3, provider, contract, isLoading }) => {
+  const createWeb3State = ({ web3, provider, contract, isLoading, chainId }) => {
     return {
       web3,
       provider,
       contract,
       isLoading,
-      hooks: setupHooks({ web3, provider, contract }),
+      chainId, // Added chainId
+      hooks: setupHooks({ web3, provider, contract }), // chainId could be passed to hooks if needed later
     };
   };
 
@@ -27,6 +28,7 @@ export default function Web3Provider({ children }) {
       provider: null,
       contract: null,
       isLoading: true,
+      chainId: null, // Initialize chainId
     })
   );
 
@@ -36,13 +38,14 @@ export default function Web3Provider({ children }) {
       if (provider) {
         const web3 = new Web3(provider);
         const contract = await loadContract("LendingAndBorrowing", web3);
+        const chainId = await web3.eth.getChainId(); // Fetch chainId
         setWeb3Api(
-          createWeb3State({ web3, provider, contract, isLoading: false })
+          createWeb3State({ web3, provider, contract, isLoading: false, chainId }) // Pass chainId
         );
         setListeners(provider);
       } else {
         console.error("Please Install metamask");
-        setWeb3Api((prevWeb3Api) => ({ ...prevWeb3Api, isLoading: false }));
+        setWeb3Api((prevWeb3Api) => ({ ...prevWeb3Api, isLoading: false, chainId: null })); // Ensure chainId is reset/handled
       }
     };
 
@@ -50,10 +53,12 @@ export default function Web3Provider({ children }) {
   }, []);
 
   const _web3Api = useMemo(() => {
-    const { web3, provider, isLoading, contract } = web3Api;
+    // Destructure chainId here if it's directly used in _web3Api's returned object computations
+    // For now, it's passed through via ...web3Api
+    // const { web3, provider, isLoading, contract, chainId } = web3Api;
 
     return {
-      ...web3Api,
+      ...web3Api, // chainId will be part of this
       requireInstall: !isLoading && !web3,
       connect: provider
         ? async () => {

--- a/components/ui/Navbar.js
+++ b/components/ui/Navbar.js
@@ -1,7 +1,30 @@
 import React from "react";
+import { useWeb3 } from "../../../components/providers/web3";
 
+const getNetworkName = (chainId) => {
+  switch (chainId) {
+    case 1:
+      return "Ethereum";
+    case 11155111:
+      return "Sepolia";
+    case 137:
+      return "Polygon";
+    case 80001:
+      return "Mumbai";
+    case 42161:
+      return "Arbitrum One";
+    case 421614:
+      return "Arbitrum Sepolia";
+    case null:
+    case undefined:
+      return "Connecting...";
+    default:
+      return "Unsupported Network";
+  }
+};
 
-export default function Navbar({accountAddress}) {
+export default function Navbar({accountAddress}) { // accountAddress is still a prop
+  const { chainId } = useWeb3();
 
   return (
     <>
@@ -20,8 +43,13 @@ export default function Navbar({accountAddress}) {
                 Dashboard
               </a>
             </div>
-            <div className="px-4 py-1 text-white border bg-gray-800 border-gray-400 rounded-md">
-              {accountAddress.slice(0,7)}...{accountAddress.slice(accountAddress.length-10)}
+            <div className="flex items-center">
+              <span className="text-white mr-3">{getNetworkName(chainId)}</span>
+              { accountAddress && // Conditionally render account if available
+                <div className="px-4 py-1 text-white border bg-gray-800 border-gray-400 rounded-md">
+                  {accountAddress.slice(0,7)}...{accountAddress.slice(accountAddress.length-10)}
+                </div>
+              }
             </div>
           </div>
           {/* Form */}

--- a/scripts/helpful_scripts.js
+++ b/scripts/helpful_scripts.js
@@ -1,25 +1,73 @@
 const MockV3Aggregator = artifacts.require('MockV3Aggregator')
 const MockDAIToken = artifacts.require('MockDAIToken')
 const Web3 = require("web3");
-const web3 = new Web3();
-var Eth = require('web3-eth');
-var eth = new Eth(Eth.givenProvider || 'ws://some.local-or-remote.node:8546');
+const web3 = new Web3(); // Used for toWei
 
-let deployed = false;
-let tokenDai = {} ;
-let mockV3 = {};
+// Removed: var Eth = require('web3-eth');
+// Removed: var eth = new Eth(Eth.givenProvider || 'ws://some.local-or-remote.node:8546');
 
-const token_address = {
-    "dai_usd_price_feed_address": '0x777A68032a88E5A84678A77Af2CD65A7b3c0775a',
-    "eth_usd_price_feed_address": '0x9326BFA02ADD2366b30bacB125260Af641031331',
-    "link_usd_price_feed_address": '0x396c5E36DD0a0F5a5D33dae44368D4193f69a1F0',
-    "fau_usd_price_feed_address": '0x777A68032a88E5A84678A77Af2CD65A7b3c0775a',
-    "dai_token_address": '0xFf795577d9AC8bD7D90Ee22b6C1703490b6512FD',
-    "weth_token_address": '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
-    "link_token_address": '0xa36085F69e2889c224210F603D836748e7dC0088',
-    "fau_token_address": '0xFab46E002BbF0b4509813474841E0716E6730136',
-    "dapp_token_address": '0x984a0522DdF80dC80286e8540479B74548f7013a'
-}
+let deployedMockDai = null;
+let deployedMockV3Aggregator = null;
+
+const network_configs = {
+    sepolia: {
+        "dai_usd_price_feed_address": "0x777A68032a88E5A84678A77Af2CD65A7b3c0775a",
+        "eth_usd_price_feed_address": "0x9326BFA02ADD2366b30bacB125260Af641031331",
+        "link_usd_price_feed_address": "0x396c5E36DD0a0F5a5D33dae44368D4193f69a1F0",
+        "fau_usd_price_feed_address": "0x777A68032a88E5A84678A77Af2CD65A7b3c0775a", // Note: Same as DAI on provided Sepolia data
+        "dai_token_address": "0xFf795577d9AC8bD7D90Ee22b6C1703490b6512FD",
+        "weth_token_address": "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // This is WETH on Kovan, ensure it's correct for Sepolia or update
+        "link_token_address": "0xa36085F69e2889c224210F603D836748e7dC0088", // This is LINK on Kovan, ensure it's correct for Sepolia or update
+        "fau_token_address": "0xFab46E002BbF0b4509813474841E0716E6730136", // This is FAU on Kovan, ensure it's correct for Sepolia or update
+        "dapp_token_address": "0x984a0522DdF80dC80286e8540479B74548f7013a" // This is a custom DappToken, ensure it's correct for Sepolia or update
+    },
+    mumbai: {
+        "dai_usd_price_feed_address": "/* TODO: Add Mumbai DAI_USD_PRICE_FEED address */",
+        "eth_usd_price_feed_address": "/* TODO: Add Mumbai MATIC_USD_PRICE_FEED address */",
+        "link_usd_price_feed_address": "/* TODO: Add Mumbai LINK_USD_PRICE_FEED address */",
+        "fau_usd_price_feed_address": "/* TODO: Add Mumbai FAU_USD_PRICE_FEED address */",
+        "dai_token_address": "/* TODO: Add Mumbai DAI_TOKEN address */",
+        "weth_token_address": "/* TODO: Add Mumbai WMATIC_TOKEN address (or WETH) */",
+        "link_token_address": "/* TODO: Add Mumbai LINK_TOKEN address */",
+        "fau_token_address": "/* TODO: Add Mumbai FAU_TOKEN address */",
+        "dapp_token_address": "/* TODO: Add Mumbai DAPP_TOKEN address */"
+    },
+    polygon: {
+        "dai_usd_price_feed_address": "/* TODO: Add Polygon Mainnet DAI_USD_PRICE_FEED address */",
+        "eth_usd_price_feed_address": "/* TODO: Add Polygon Mainnet MATIC_USD_PRICE_FEED address */",
+        "link_usd_price_feed_address": "/* TODO: Add Polygon Mainnet LINK_USD_PRICE_FEED address */",
+        "fau_usd_price_feed_address": "/* TODO: Add Polygon Mainnet FAU_USD_PRICE_FEED address */",
+        "dai_token_address": "/* TODO: Add Polygon Mainnet DAI_TOKEN address */",
+        "weth_token_address": "/* TODO: Add Polygon Mainnet WMATIC_TOKEN address (or WETH) */",
+        "link_token_address": "/* TODO: Add Polygon Mainnet LINK_TOKEN address */",
+        "fau_token_address": "/* TODO: Add Polygon Mainnet FAU_TOKEN address */",
+        "dapp_token_address": "/* TODO: Add Polygon Mainnet DAPP_TOKEN address */"
+    },
+    arbitrumOne: {
+        "dai_usd_price_feed_address": "/* TODO: Add Arbitrum One DAI_USD_PRICE_FEED address */",
+        "eth_usd_price_feed_address": "/* TODO: Add Arbitrum One ETH_USD_PRICE_FEED address */",
+        "link_usd_price_feed_address": "/* TODO: Add Arbitrum One LINK_USD_PRICE_FEED address */",
+        "fau_usd_price_feed_address": "/* TODO: Add Arbitrum One FAU_USD_PRICE_FEED address */",
+        "dai_token_address": "/* TODO: Add Arbitrum One DAI_TOKEN address */",
+        "weth_token_address": "/* TODO: Add Arbitrum One WETH_TOKEN address */",
+        "link_token_address": "/* TODO: Add Arbitrum One LINK_TOKEN address */",
+        "fau_token_address": "/* TODO: Add Arbitrum One FAU_TOKEN address */",
+        "dapp_token_address": "/* TODO: Add Arbitrum One DAPP_TOKEN address */"
+    },
+    arbitrumSepolia: {
+        "dai_usd_price_feed_address": "/* TODO: Add Arbitrum Sepolia DAI_USD_PRICE_FEED address */",
+        "eth_usd_price_feed_address": "/* TODO: Add Arbitrum Sepolia ETH_USD_PRICE_FEED address */",
+        "link_usd_price_feed_address": "/* TODO: Add Arbitrum Sepolia LINK_USD_PRICE_FEED address */",
+        "fau_usd_price_feed_address": "/* TODO: Add Arbitrum Sepolia FAU_USD_PRICE_FEED address */",
+        "dai_token_address": "/* TODO: Add Arbitrum Sepolia DAI_TOKEN address */",
+        "weth_token_address": "/* TODO: Add Arbitrum Sepolia WETH_TOKEN address */",
+        "link_token_address": "/* TODO: Add Arbitrum Sepolia LINK_TOKEN address */",
+        "fau_token_address": "/* TODO: Add Arbitrum Sepolia FAU_TOKEN address */",
+        "dapp_token_address": "/* TODO: Add Arbitrum Sepolia DAPP_TOKEN address */"
+    }
+};
+
+// Removed: token_address global variable
 
 function toWei(amount){
   return web3.utils.toWei(amount, "ether")
@@ -32,43 +80,66 @@ const contract_to_mock = {
     "link_usd_price_feed_address": MockV3Aggregator,
     "fau_usd_price_feed_address": MockV3Aggregator,
     "dai_token_address": MockDAIToken,
-    "weth_token_address": MockDAIToken,
-    "link_token_address": MockDAIToken,
-    "fau_token_address": MockDAIToken,
-    "dapp_token_address": MockDAIToken
-}
+    "weth_token_address": MockDAIToken, // Assuming MockDAIToken can represent generic ERC20
+    "link_token_address": MockDAIToken, // Assuming MockDAIToken can represent generic ERC20
+    "fau_token_address": MockDAIToken,  // Assuming MockDAIToken can represent generic ERC20
+    "dapp_token_address": MockDAIToken  // Assuming MockDAIToken can represent generic ERC20
+};
 
 const deploy_mocks = async(deployer) =>{
-  await deployer.deploy(MockDAIToken)
-  await deployer.deploy(MockV3Aggregator, 8, 2 * 10**8)
-  tokenDai = await MockDAIToken.deployed()
-  mockV3 = await MockV3Aggregator.deployed()
-  deployed = true;
-  return [tokenDai.address,mockV3._address]
-}
-
+  if (!deployedMockDai) {
+    await deployer.deploy(MockDAIToken);
+    deployedMockDai = await MockDAIToken.deployed();
+  }
+  if (!deployedMockV3Aggregator) {
+    await deployer.deploy(MockV3Aggregator, 8, 2 * 10**8); // 8 decimals, 200000000 initial answer
+    deployedMockV3Aggregator = await MockV3Aggregator.deployed();
+  }
+  return {
+    daiTokenAddress: deployedMockDai.address,
+    mockV3AggregatorAddress: deployedMockV3Aggregator.address
+  };
+};
 
 const get_contract = async(contract_name, current_network, current_deployer)=>{
-    //If we are on a local network, deploy a mock contract and return the contract
-    //If we are on a real network, Obtain a contract from abi and name of that mock contract.
     let contract_addr;
-    let contract_type = contract_to_mock[contract_name]
-    if(current_network == "development"){
-        if (deployed)
-        {
-          contract_addr = contract_type["contractName"] == "MockDAIToken" ? tokenDai.address : mockV3.address
-        }
-        else{
-          var token = await deploy_mocks(current_deployer)
-          contract_addr = contract_type["contractName"] == "MockDAIToken" ? token[0]: token[1]
-        }
-    }
-    else //for Production
-    {
-        contract = new web3.eth.Contract(contract_type.abi, token_address[contract_name])
-        contract_addr = contract._address
-    }
-    return contract_addr
-}
+    const contract_type = contract_to_mock[contract_name];
 
-module.exports = { get_contract, deploy_mocks, contract_to_mock, toWei }
+    if (!contract_type) {
+        throw new Error(`Configuration for ${contract_name} not found in contract_to_mock.`);
+    }
+
+    if(current_network == "development"){
+        // Deploy mocks if not already deployed for the session
+        if (!deployedMockDai || !deployedMockV3Aggregator) {
+            await deploy_mocks(current_deployer);
+        }
+        // Return the address of the appropriate mock contract
+        if (contract_type.contractName == "MockDAIToken") {
+            contract_addr = deployedMockDai.address;
+        } else if (contract_type.contractName == "MockV3Aggregator") {
+            contract_addr = deployedMockV3Aggregator.address;
+        } else {
+            throw new Error(`Mock type for ${contract_name} with contract type ${contract_type.contractName} is not recognized for deployment.`);
+        }
+    }
+    else // For Production/Testnets
+    {
+        if (!network_configs[current_network]) {
+            throw new Error(`Network configuration for '${current_network}' not found.`);
+        }
+        contract_addr = network_configs[current_network][contract_name];
+        if (!contract_addr || contract_addr.startsWith("/* TODO:")) {
+            throw new Error(`Address for '${contract_name}' on network '${current_network}' is not configured or is a placeholder. Please update helpful_scripts.js.`);
+        }
+        // Removed: contract = new web3.eth.Contract(contract_type.abi, token_address[contract_name])
+        // The function now directly returns the address string.
+    }
+
+    if (!contract_addr) {
+        throw new Error(`Could not determine address for ${contract_name} on network ${current_network}.`);
+    }
+    return contract_addr;
+};
+
+module.exports = { get_contract, deploy_mocks, contract_to_mock, toWei, network_configs };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,11 +1,37 @@
 require('babel-register');
 require('babel-polyfill');
 const path = require("path");
-const HDWalletProvider = require('./node_modules/@truffle/hdwallet-provider');
+const HDWalletProvider = require('./node_modules/@truffle/hdwallet-provider'); // Keeping existing import path
 require('./node_modules/dotenv').config();
 
-const MNEMONIC = process.env.MNEMONIC;
-const INFURA_API_KEY = process.env.INFURA_API_KEY;
+// Environment variable validation can be done here or within each provider function.
+// For clarity, basic checks are included in provider functions.
+
+// Ensure these are declared in your .env file:
+//
+// For Sepolia:
+// SEPOLIA_PRIVATE_KEY="YOUR_SEPOLIA_PRIVATE_KEY"
+// INFURA_API_KEY="YOUR_INFURA_API_KEY" (or your specific Sepolia RPC URL provider's key)
+//
+// For Polygon Mainnet:
+// POLYGON_MAINNET_PRIVATE_KEY="YOUR_POLYGON_MAINNET_PRIVATE_KEY"
+// POLYGON_MAINNET_RPC_URL="YOUR_POLYGON_MAINNET_RPC_URL"
+//
+// For Polygon Mumbai Testnet:
+// POLYGON_MUMBAI_PRIVATE_KEY="YOUR_POLYGON_MUMBAI_PRIVATE_KEY"
+// POLYGON_MUMBAI_RPC_URL="YOUR_POLYGON_MUMBAI_RPC_URL"
+//
+// For Arbitrum One Mainnet:
+// ARBITRUM_ONE_PRIVATE_KEY="YOUR_ARBITRUM_ONE_PRIVATE_KEY"
+// ARBITRUM_ONE_RPC_URL="YOUR_ARBITRUM_ONE_RPC_URL"
+//
+// For Arbitrum Sepolia Testnet:
+// ARBITRUM_SEPOLIA_PRIVATE_KEY="YOUR_ARBITRUM_SEPOLIA_PRIVATE_KEY"
+// ARBITRUM_SEPOLIA_RPC_URL="YOUR_ARBITRUM_SEPOLIA_RPC_URL"
+// ARBISCAN_API_KEY="YOUR_ARBISCAN_API_KEY" (Optional, for contract verification)
+
+// Removed: const MNEMONIC = process.env.MNEMONIC;
+// Removed: const INFURA_API_KEY = process.env.INFURA_API_KEY; // Defined locally or used directly
 
 module.exports = {
   networks: {
@@ -17,13 +43,78 @@ module.exports = {
     },
     sepolia: {
       provider: function(){
+        if (!process.env.SEPOLIA_PRIVATE_KEY || !process.env.INFURA_API_KEY) {
+          throw new Error("SEPOLIA_PRIVATE_KEY and INFURA_API_KEY must be set in .env for Sepolia network.");
+        }
         return new HDWalletProvider(
-          MNEMONIC,
-          `https://sepolia.infura.io/v3/${INFURA_API_KEY}`
-        )
+          process.env.SEPOLIA_PRIVATE_KEY,
+          `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY}`
+        );
       },
-      gas_price: 25000000000,
+      gas_price: 25000000000, // Consider adjusting gas price based on network conditions
       network_id: 11155111
+    },
+    polygon: {
+      provider: () => {
+        if (!process.env.POLYGON_MAINNET_PRIVATE_KEY || !process.env.POLYGON_MAINNET_RPC_URL) {
+          throw new Error("POLYGON_MAINNET_PRIVATE_KEY and POLYGON_MAINNET_RPC_URL must be set in .env for Polygon Mainnet.");
+        }
+        return new HDWalletProvider(
+          process.env.POLYGON_MAINNET_PRIVATE_KEY,
+          process.env.POLYGON_MAINNET_RPC_URL
+        );
+      },
+      network_id: 137,
+      gasPrice: 50000000000, // Adjust as needed
+      // confirmations: 2,
+      // timeoutBlocks: 200,
+      // skipDryRun: true
+    },
+    mumbai: {
+      provider: () => {
+        if (!process.env.POLYGON_MUMBAI_PRIVATE_KEY || !process.env.POLYGON_MUMBAI_RPC_URL) {
+          throw new Error("POLYGON_MUMBAI_PRIVATE_KEY and POLYGON_MUMBAI_RPC_URL must be set in .env for Mumbai Testnet.");
+        }
+        return new HDWalletProvider(
+          process.env.POLYGON_MUMBAI_PRIVATE_KEY,
+          process.env.POLYGON_MUMBAI_RPC_URL
+        );
+      },
+      network_id: 80001,
+      gasPrice: 35000000000, // Adjust as needed
+      // confirmations: 2,
+      // timeoutBlocks: 200,
+      // skipDryRun: true
+    },
+    arbitrumOne: {
+      provider: () => {
+        if (!process.env.ARBITRUM_ONE_PRIVATE_KEY || !process.env.ARBITRUM_ONE_RPC_URL) {
+          throw new Error("ARBITRUM_ONE_PRIVATE_KEY and ARBITRUM_ONE_RPC_URL must be set in .env for Arbitrum One.");
+        }
+        return new HDWalletProvider(
+          process.env.ARBITRUM_ONE_PRIVATE_KEY,
+          process.env.ARBITRUM_ONE_RPC_URL
+        );
+      },
+      network_id: 42161,
+      // gasPrice and blockGasLimit might need specific settings for Arbitrum
+    },
+    arbitrumSepolia: {
+      provider: () => {
+        if (!process.env.ARBITRUM_SEPOLIA_PRIVATE_KEY || !process.env.ARBITRUM_SEPOLIA_RPC_URL) {
+          throw new Error("ARBITRUM_SEPOLIA_PRIVATE_KEY and ARBITRUM_SEPOLIA_RPC_URL must be set in .env for Arbitrum Sepolia.");
+        }
+        return new HDWalletProvider(
+          process.env.ARBITRUM_SEPOLIA_PRIVATE_KEY,
+          process.env.ARBITRUM_SEPOLIA_RPC_URL
+        );
+      },
+      network_id: 421614,
+      // verify: { // Optional: Configuration for block explorer verification
+      //   apiUrl: 'https://api-sepolia.arbiscan.io/api',
+      //   apiKey: process.env.ARBISCAN_API_KEY, // Ensure ARBISCAN_API_KEY is in .env
+      //   explorerUrl: 'https://sepolia.arbiscan.io/address/<address>',
+      // }
     }
   },
   contracts_directory: './contracts/',
@@ -37,11 +128,15 @@ module.exports = {
           enabled: true,
           runs: 1
         }
-      },
-      mocha: {
-        reporter: 'eth-gas-reporter',
       }
     }
   },
+  mocha: {
+    reporter: 'eth-gas-reporter',
+    reporterOptions : { // Optional
+      currency: 'USD',
+      gasPrice: 21 // Optional
+    }
+  },
   plugins: ["truffle-contract-size"]
-}
+};


### PR DESCRIPTION
This change modifies `truffle-config.js` so that it uses private keys instead of mnemonics for network wallet configurations.

- I updated the HDWalletProvider instantiation for Sepolia, Polygon (Mainnet, Mumbai), and Arbitrum (Arbitrum One, Arbitrum Sepolia) to accept private keys.
- I changed the corresponding environment variable names (e.g., SEPOLIA_PRIVATE_KEY, POLYGON_MAINNET_PRIVATE_KEY, ARBITRUM_ONE_PRIVATE_KEY).
- I updated the comments to guide you on setting these new private key environment variables.
- I added basic error handling for missing private key or RPC URL environment variables.